### PR TITLE
Auto-refresh Monitor, Download, and Running tabs; remove reload buttons

### DIFF
--- a/popup/index.html
+++ b/popup/index.html
@@ -25,7 +25,6 @@
 			<div id="monitor-page" class="show">
 				<div>
 					<span id="monitor-count" class="badge" data-title="monitorMonitoredCount">-</span>
-					<span class="badge badge-b" id="monitor-reload" data-msg="reload">reload</span>
 					<span class="badge badge-b" id="monitor-clean" data-msg="clean">clean</span>
                     <span>
                         <select id="monitor-filter" class="empty-select" data-title="filter" >
@@ -70,7 +69,6 @@
 					<span id="download-downloading-count" class="badge" data-title="downloadDlingCount">-</span>
 					<span class="badge badge-c" id="download-batch-show" data-msg="downloadBatchShow">batch</span>
 					<span id="download-batch-count" class="badge" data-title="downloadBatchCount">-</span>
-					<span class="badge badge-b" id="download-reload" data-msg="reload" data-title="downloadReloadTip">reload</span>
                     <span><input type="text" id="download-copyholder" class="copyholder" /></span>
 				</div>
 				<div>
@@ -170,9 +168,6 @@
 				
 			</div>
 			<div id="running-page" class="hide">
-				<div>
-					<span class="badge badge-b" id="running-reload" data-msg="reload">reload</span>
-				</div>
 				<div id="running-content">
 				</div>
 			</div>

--- a/popup/index.js
+++ b/popup/index.js
@@ -38,11 +38,6 @@ document.addEventListener("DOMContentLoaded", function () {
 	
 	//monitor
 	(function(){
-		document.getElementById("monitor-reload").onclick = function(e){
-			e.stopPropagation();
-			loadMonitoredMedia();
-		};
-		
 		document.getElementById("monitor-clean").onclick = function(e){
 			e.stopPropagation();
 			cleanMonitoredMedia();
@@ -226,6 +221,9 @@ document.addEventListener("DOMContentLoaded", function () {
 				destroy && loadMonitoredMedia();
 			});
 		}
+		
+		loadMonitoredMedia();
+		setInterval(loadMonitoredMedia, 3000);
 	})();
 	
 	
@@ -311,13 +309,7 @@ document.addEventListener("DOMContentLoaded", function () {
 			
 		})();
 		
-	
-		document.getElementById("download-reload").onclick = function(e){
-			e.stopPropagation();
-			metricDownload();
-		}
-		
-		
+
 		function metricDownload(){
 			chrome.runtime.sendMessage({
 				action: "metricdownload"
@@ -538,6 +530,8 @@ document.addEventListener("DOMContentLoaded", function () {
             }
         }
         
+		metricDownload();
+		setInterval(metricDownload, 3000);
 	})();
 	
 	
@@ -704,11 +698,6 @@ document.addEventListener("DOMContentLoaded", function () {
 	
 	//running
 	(function(){
-		document.getElementById("running-reload").onclick = function(e){
-			e.stopPropagation();
-			loadRunningInfo();
-		};
-		
 		function loadRunningInfo(){
 			var contentDom = document.getElementById("running-content");
 			contentDom.innerHTML = "......";
@@ -728,6 +717,9 @@ document.addEventListener("DOMContentLoaded", function () {
 				contentDom.innerHTML = html;
 			});
 		}
+		
+		loadRunningInfo();
+		setInterval(loadRunningInfo, 3000);
 	})();
 	
 });


### PR DESCRIPTION
The Monitor, Download, and Running tabs required manual reloads to see updated state. This replaces the explicit reload buttons with automatic 3-second polling.

## Changes

- **`popup/index.html`**: Removed `monitor-reload`, `download-reload`, and `running-reload` buttons (including the now-empty wrapper `<div>` in the Running tab)
- **`popup/index.js`**: For each of the three tabs, removed the reload button `onclick` handler and added an immediate initial load + `setInterval(..., 3000)` auto-refresh:

```js
loadMonitoredMedia();
setInterval(loadMonitoredMedia, 3000);
```

Intervals are scoped to the popup page lifetime and are automatically torn down when the popup is closed.

<!-- START COPILOT ORIGINAL PROMPT -->



<details>

<summary>Original prompt</summary>

> 
> ----
> 
> *This section details on the original issue you should resolve*
> 
> <issue_title>Auto refresh the Monitor, Download and Running tabs in the box shown after clicking its icon</issue_title>
> <issue_description>Auto refresh the Monitor, Download and Running tabs in the box shown after clicking its icon. Then remove the reload button in those tabs since they are being auto refreshed.</issue_description>
> 
> ## Comments on the Issue (you are @copilot in this section)
> 
> <comments>
> </comments>
> 


</details>



<!-- START COPILOT CODING AGENT SUFFIX -->

- Fixes Zero3K20/m3u8-downloader#1

<!-- START COPILOT CODING AGENT TIPS -->
---

💡 You can make Copilot smarter by setting up custom instructions, customizing its development environment and configuring Model Context Protocol (MCP) servers. Learn more [Copilot coding agent tips](https://gh.io/copilot-coding-agent-tips) in the docs.