### PR TITLE
Hide m3u8 segment downloads from Chrome's download list

### DIFF
--- a/js/mychromedownload.js
+++ b/js/mychromedownload.js
@@ -19,6 +19,12 @@ var MyChromeDownload = (function () {
 		if (delta.state && delta.state.current == "complete") {
 			MyDownload.downloadingHolder.delete(delta.id);
 			MyDownload.downloadBatchHolder.complete(control.batchName);
+			if(control.hideInDownloadList){
+				chrome.downloads.erase({id: delta.id}, function(){
+					if(chrome.runtime.lastError){
+					}
+				});
+			}
 		}
 		
 		if (delta.state){

--- a/js/mychromem3u8processer.js
+++ b/js/mychromem3u8processer.js
@@ -101,7 +101,8 @@ var MyChromeM3u8Processer = (function () {
                     url: url,
                     filename: data.downloadDirectory + "/segment/" + fileName
                 },
-                target: "chrome"
+                target: "chrome",
+                hideInDownloadList: true
             }], 
             showName: fileName,
             priority: true

--- a/js/mydownload.js
+++ b/js/mydownload.js
@@ -28,6 +28,7 @@ var MyDownload = (function () {
                     task.control.url = task.options.url;
                     task.control.canResume = false;
                     task.control.target = task.target;
+                    task.control.hideInDownloadList = task.hideInDownloadList || false;
 				}
                 if(isUpdate){
                     for(var x in _queue){


### PR DESCRIPTION
When downloading m3u8 video/live streams, each individual `.ts` segment file is queued through `chrome.downloads.download()`, flooding Chrome's download history and the Downloads shelf with hundreds of intermediate files.

## Changes

- **`mychromem3u8processer.js`**: Tag segment download tasks with `hideInDownloadList: true` in `_downloadM3u8Ts()`.
- **`mydownload.js`**: Propagate `hideInDownloadList` from task to `task.control` in `_downloadBatchHolder.offer()`.
- **`mychromedownload.js`**: On download completion, erase flagged entries from Chrome's download history via `chrome.downloads.erase()`.

```js
// mychromedownload.js — onChanged handler
if (delta.state && delta.state.current == "complete") {
    MyDownload.downloadingHolder.delete(delta.id);
    MyDownload.downloadBatchHolder.complete(control.batchName);
    if(control.hideInDownloadList){
        chrome.downloads.erase({id: delta.id}, function(){
            if(chrome.runtime.lastError){}
        });
    }
}
```

Only `.ts` segment files (intermediate, auto-merged) are erased. Final outputs — processer scripts, `.m3u8` playlists, and the merged video — remain visible in the download list.

<!-- START COPILOT ORIGINAL PROMPT -->



<details>

<summary>Original prompt</summary>

> 
> ----
> 
> *This section details on the original issue you should resolve*
> 
> <issue_title>Find a way to hide the downloading of the segments when downloading a m3u8 video/live stream</issue_title>
> <issue_description>Find a way to hide the display of the downloaded segments in the Download List and when clicking on the Downloads icon that happens when downloading a m3u8 video/live stream.</issue_description>
> 
> ## Comments on the Issue (you are @copilot in this section)
> 
> <comments>
> </comments>
> 


</details>



<!-- START COPILOT CODING AGENT SUFFIX -->

- Fixes Zero3K20/m3u8-downloader#2

<!-- START COPILOT CODING AGENT TIPS -->
---

💡 You can make Copilot smarter by setting up custom instructions, customizing its development environment and configuring Model Context Protocol (MCP) servers. Learn more [Copilot coding agent tips](https://gh.io/copilot-coding-agent-tips) in the docs.