### PR TITLE
Use media name as download directory for identifiable segment folders

### DIFF
--- a/js/mym3u8processer.js
+++ b/js/mym3u8processer.js
@@ -249,8 +249,8 @@ var MyM3u8Processer = (function () {
         }
 
         const uniqueKey = data.originalContextId || MyUtils.genRandomString();
-		const downloadDirectory = chrome.i18n.getMessage("appName") + "-" + uniqueKey;
         const mediaName = MyUtils.buildMediaName(data.mediaName, data.reqConfig.url, parseResult.suffix);
+		const downloadDirectory = MyUtils.trimSuffix(mediaName) + "-" + uniqueKey.substring(0, 8);
         
         const context = MyBaseProcesser.saveDownloadContext({
             id: uniqueKey,


### PR DESCRIPTION
The download directory was named `{appName}-{randomKey}` (e.g., `m3u8 downloader-170600000000003849261847`), making it impossible to identify which folder belongs to which download. Segments in Chrome M3u8 processer mode were buried in an opaque path.

## Change

In `mym3u8processer.js`, `downloadDirectory` now derives from the media name with a short unique suffix:

```js
// Before
const downloadDirectory = chrome.i18n.getMessage("appName") + "-" + uniqueKey;

// After
const mediaName = MyUtils.buildMediaName(data.mediaName, data.reqConfig.url, parseResult.suffix);
const downloadDirectory = MyUtils.trimSuffix(mediaName) + "-" + uniqueKey.substring(0, 8);
```

**Resulting folder structure (Chrome M3u8 processer mode):**
```
my_video-17060000/
  processer/   ← merge scripts
  m3u8/        ← playlists
  segment/     ← TS segments
```

- The short `uniqueKey` prefix prevents collisions on same-named downloads
- Processer scripts are unaffected — they reference `../segment/` and `../m3u8/` relative to their own directory
- `newFolderAtRoot=0` behavior unchanged: merged output still goes directly to downloads root

<!-- START COPILOT ORIGINAL PROMPT -->



<details>

<summary>Original prompt</summary>

> 
> ----
> 
> *This section details on the original issue you should resolve*
> 
> <issue_title>Have the segments be downloaded into a separate folder if possible</issue_title>
> <issue_description>Have the segments be downloaded into a separate folder if possible.</issue_description>
> 
> ## Comments on the Issue (you are @copilot in this section)
> 
> <comments>
> </comments>
> 


</details>



<!-- START COPILOT CODING AGENT SUFFIX -->

- Fixes Zero3K20/m3u8-downloader#3

<!-- START COPILOT CODING AGENT TIPS -->
---

✨ Let Copilot coding agent [set things up for you](https://github.com/Zero3K20/m3u8-downloader/issues/new?title=✨+Set+up+Copilot+instructions&body=Configure%20instructions%20for%20this%20repository%20as%20documented%20in%20%5BBest%20practices%20for%20Copilot%20coding%20agent%20in%20your%20repository%5D%28https://gh.io/copilot-coding-agent-tips%29%2E%0A%0A%3COnboard%20this%20repo%3E&assignees=copilot) — coding agent works faster and does higher quality work when set up for your repo.
