### PR TITLE
Make browser action icon open popup in a new window

### DIFF
--- a/js/mybootstrap.js
+++ b/js/mybootstrap.js
@@ -92,6 +92,15 @@ var MyBootstrap = (function () {
 		});
         
         _updateIcon(! MyChromeMediaMonitor.isEmpty() );
+
+		chrome.browserAction.onClicked.addListener(function(){
+			chrome.windows.create({
+				url: chrome.runtime.getURL("popup/index.html"),
+				type: "popup",
+				width: MyChromeConfig.get("popupWidth"),
+				height: MyChromeConfig.get("popupHeight")
+			});
+		});
 	}
 	
 	

--- a/js/mybootstrap.js
+++ b/js/mybootstrap.js
@@ -92,15 +92,6 @@ var MyBootstrap = (function () {
 		});
         
         _updateIcon(! MyChromeMediaMonitor.isEmpty() );
-
-		chrome.browserAction.onClicked.addListener(function(){
-			chrome.windows.create({
-				url: chrome.runtime.getURL("popup/index.html"),
-				type: "popup",
-				width: MyChromeConfig.get("popupWidth"),
-				height: MyChromeConfig.get("popupHeight")
-			});
-		});
 	}
 	
 	

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,8 @@
     "browser_action": {
         "default_icon": {
             "128": "img/icon128.png"
-        }
+        },
+        "default_popup": "popup/index.html"
     },
     "background": {
         "scripts": ["js/myutils.js", "js/myreader.js",

--- a/manifest.json
+++ b/manifest.json
@@ -11,8 +11,7 @@
     "browser_action": {
         "default_icon": {
             "128": "img/icon128.png"
-        },
-		"default_popup": "popup/index.html"
+        }
     },
     "background": {
         "scripts": ["js/myutils.js", "js/myreader.js",

--- a/popup/index.js
+++ b/popup/index.js
@@ -1,3 +1,22 @@
+(function() {
+	var views = chrome.extension.getViews({ type: "popup" });
+	if (views.indexOf(window) !== -1) {
+		chrome.runtime.sendMessage({ action: "getconfig" }, function(config) {
+			if (chrome.runtime.lastError || !config) {
+				return;
+			}
+			chrome.windows.create({
+				url: chrome.runtime.getURL("popup/index.html"),
+				type: "popup",
+				width: config.popupWidth || 462,
+				height: config.popupHeight || 435
+			}, function() {
+				window.close();
+			});
+		});
+	}
+})();
+
 document.addEventListener("DOMContentLoaded", function () {
 	
 	//show ui

--- a/popup/index.js
+++ b/popup/index.js
@@ -9,7 +9,8 @@
 				url: chrome.runtime.getURL("popup/index.html"),
 				type: "popup",
 				width: config.popupWidth || 462,
-				height: config.popupHeight || 435
+				height: config.popupHeight || 435,
+				alwaysOnTop: true
 			}, function() {
 				window.close();
 			});


### PR DESCRIPTION
Clicking the extension icon should open the UI in a persistent, always-on-top window rather than the transient browser action dropdown.

## Changes

- **`manifest.json`**: Restored `default_popup` so Chrome reliably triggers the popup on icon click.
- **`popup/index.js`**: Added self-redirect at script start — detects when running as a browser action popup via `chrome.extension.getViews({type: "popup"})`, then opens the same page as a standalone `chrome.windows.create` popup (`alwaysOnTop: true`, sized from saved config) and closes the dropdown.
- **`mybootstrap.js`**: Removed the previously attempted (non-functional) `browserAction.onClicked` listener.

```js
chrome.windows.create({
    url: chrome.runtime.getURL("popup/index.html"),
    type: "popup",
    width: config.popupWidth || 462,
    height: config.popupHeight || 435,
    alwaysOnTop: true
}, function() {
    window.close();
});
```

`getViews({type: "popup"})` only matches browser action popups, not `popup`-type windows, so there is no redirect loop.

<!-- START COPILOT ORIGINAL PROMPT -->



<details>

<summary>Original prompt</summary>

> 
> ----
> 
> *This section details on the original issue you should resolve*
> 
> <issue_title>Make clicking its icon open its box in a new window</issue_title>
> <issue_description>Make clicking its icon open its box in a new window</issue_description>
> 
> ## Comments on the Issue (you are @copilot in this section)
> 
> <comments>
> </comments>
> 


</details>



<!-- START COPILOT CODING AGENT SUFFIX -->

- Fixes Zero3K20/m3u8-downloader#11

<!-- START COPILOT CODING AGENT TIPS -->
---

🔒 GitHub Advanced Security automatically protects Copilot coding agent pull requests. You can protect all pull requests by enabling Advanced Security for your repositories. [Learn more about Advanced Security.](https://gh.io/cca-advanced-security)